### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ctr6h/d04d928e-1c0d-4af3-adf7-e67f58dd78d1/fdae7e54-13d2-4d92-ba20-a0799cdd0f51/_apis/work/boardbadge/3fa5191d-5a9d-4dd5-8fec-654d96e4780f)](https://dev.azure.com/ctr6h/d04d928e-1c0d-4af3-adf7-e67f58dd78d1/_boards/board/t/fdae7e54-13d2-4d92-ba20-a0799cdd0f51/Microsoft.RequirementCategory)
 # Android_Hacking
 ![GitHub last commit](https://img.shields.io/github/last-commit/AzimsTech/Android_Hacking)
 ![Site cover](cover.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ctr6h/d04d928e-1c0d-4af3-adf7-e67f58dd78d1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.